### PR TITLE
请升级org.springframework:spring-webmvc组件版本以解决1个安全漏洞

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-webmvc</artifactId>
-				<version>5.3.18</version>
+				<version>6.0.7</version>>
 			</dependency>
 			<dependency>
 				<groupId>com.alibaba</groupId>


### PR DESCRIPTION
将 **org.springframework:spring-webmvc** 组件从5.3.18 版本升级至 6.0.7版本,
用于修复以下安全漏洞：


序号 | 漏洞编号 | 漏洞标题 | 漏洞级别
-- | -- | -- | --
1 | [MPS-2022-62832](https://www.oscs1024.com/hd/MPS-2022-62832) | Spring Security通配符路由绕过漏洞 | 高危
  |   |   |   


<br/>

_注意 ：此 PR 由您（或拥有此仓库权限的其他维护者）授权 [墨菲安全](https://www.murphysec.com) 打开_

了解更多：
- [如何快速修复代码安全问题](https://www.murphysec.com/docs/faqs/security-issues/how-to-quick-fixes.html)
